### PR TITLE
correct location for tenantFilter in filter-mappings

### DIFF
--- a/src/groovy/grails/plugin/multitenant/singledb/MtSingleDbPluginSupport.groovy
+++ b/src/groovy/grails/plugin/multitenant/singledb/MtSingleDbPluginSupport.groovy
@@ -153,8 +153,10 @@ class MtSingleDbPluginSupport {
             }
         }
 
-        def filter = xml.'filter'
-        filter[filter.size() - 1] + {
+        def filterMappings = xml.'filter-mapping'
+        // insert tenantFilter just after grailsWebRequest and before the sitemesh filter
+        def grailsWebRequestFilterMapping = filterMappings.find  { it.'filter-name'.text() == 'grailsWebRequest' }
+        grailsWebRequestFilterMapping  + {
             'filter-mapping' {
                 'filter-name'('tenantFilter')
                 'url-pattern'('/*')


### PR DESCRIPTION
Previously, the plugin puts the multiTenantFilter as the very first filter. This leads to trouble if spring-security-core is used in the project since spring-security-core'
s filter is add to a later point in the chain, a TenantResolver could not access SpringSecurityContextHolder. So we must make sure that tenantFilter is processed after the spring-security-core filter. SSC hooks its filter right after grailsWebRequest and does this in _Events as post operation - for multiTenant it is sufficient to place its filter after grailsWebRequest
So the order is now:
charEncodingFilter - hiddenHttpMethod - grailsWebRequest - springsecuritycore - mulitTenant - sitemesh
