### PR TITLE
Various updates to fix the build

### DIFF
--- a/MultiTenantSingleDbGrailsPlugin.groovy
+++ b/MultiTenantSingleDbGrailsPlugin.groovy
@@ -2,7 +2,7 @@ import grails.plugin.multitenant.singledb.MtSingleDbPluginSupport
 
 class MultiTenantSingleDbGrailsPlugin {
 
-    def version = "0.8.1"
+    def version = "0.8.2-SNAPSHOT"
     def grailsVersion = "1.3.5 > *"
 
     def dependsOn = [:] // does not play well with Maven repositories

--- a/application.properties
+++ b/application.properties
@@ -1,9 +1,4 @@
 #Grails Metadata file
-#Mon Dec 19 13:08:58 CET 2011
+#Mon Jan 16 19:37:35 CST 2012
 app.grails.version=2.0.0
 app.name=multi-tenant-single-db
-plugins.hawk-eventing=0.5.1
-plugins.hibernate=2.0.0
-plugins.release=1.0.0.M2
-plugins.spock=0.5-groovy-1.7
-plugins.tomcat=2.0.0

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -29,8 +29,24 @@ grails.project.dependency.resolution = {
     }
     
     plugins {
-        provided ':webxml:1.4'
-        //compile ':hibernate-hijacker:0.8.1'
+		build(':release:1.0.1'){ export = false }
+		build(':svn:1.0.2') { export = false }
+		build(":tomcat:$grailsVersion") { export = false }
+		
+		compile(":hibernate:$grailsVersion") { export = false }
+
+		provided ':webxml:1.4'
+		compile(':hawk-eventing:0.5.1'){
+			excludes 'svn'
+		}
+		
+		compile(':hibernate-hijacker:0.8.1'){
+			excludes 'svn'
+		}
+
+		test(':spock:0.6-SNAPSHOT'){
+			excludes 'svn'
+		}
     }
     
 }

--- a/grails-app/conf/DataSource.groovy
+++ b/grails-app/conf/DataSource.groovy
@@ -1,6 +1,6 @@
 dataSource {
     pooled = true
-    driverClassName = "org.hsqldb.jdbcDriver"
+    driverClassName = "org.h2.Driver"
     username = "sa"
     password = ""
 }
@@ -15,19 +15,19 @@ environments {
     development {
         dataSource {
             dbCreate = "create-drop" // one of 'create', 'create-drop','update'
-            url = "jdbc:hsqldb:mem:devDB"
+            url = "jdbc:h2:mem:devDB"
         }
     }
     test {
         dataSource {
             dbCreate = "update"
-            url = "jdbc:hsqldb:mem:testDb"
+            url = "jdbc:h2:mem:testDb"
         }
     }
     production {
         dataSource {
             dbCreate = "update"
-            url = "jdbc:hsqldb:file:prodDb;shutdown=true"
+            url = "jdbc:h2:file:prodDb;shutdown=true"
         }
     }
 }

--- a/test/integration/grails/plugin/multitenant/singledb/hibernate/TenantHibernateFilterEnablerSpec.groovy
+++ b/test/integration/grails/plugin/multitenant/singledb/hibernate/TenantHibernateFilterEnablerSpec.groovy
@@ -32,7 +32,7 @@ class TenantHibernateFilterEnablerSpec extends IntegrationSpec {
         enabledFilter == null
     }
     
-    @Unroll("Enabling multi-tenant Hibernate filter with tenant id #tenantId")
+    @Unroll({"Enabling multi-tenant Hibernate filter with tenant id #tenantId"})
     def "negative and positive numbers makes it to the filter"() {
         when:
         Event updatedTenantEvent = new BaseEvent("multitenant.set-current-tenant.after", tenantId)

--- a/test/unit/grails/plugin/multitenant/singledb/MtSingleDbPluginSupportSpec.groovy
+++ b/test/unit/grails/plugin/multitenant/singledb/MtSingleDbPluginSupportSpec.groovy
@@ -16,11 +16,11 @@ class MtSingleDbPluginSupportSpec extends UnitSpec {
     def "add withTenantId method"() {
         given:
         MultiTenantService mockedMtService = Mock()
-        MetaTenant tenant = new MetaTenant()
         
         when: "we add a withThisTenant method to the class"
         MtSingleDbPluginSupport.createWithThisTenantMethod(MetaTenant, mockedMtService)
-        
+		MetaTenant tenant = new MetaTenant()
+		
         and: "and invoke it"
         tenant.withThisTenant(null)
         

--- a/test/unit/grails/plugin/multitenant/singledb/hibernate/TenantHibernateEventListenerSpec.groovy
+++ b/test/unit/grails/plugin/multitenant/singledb/hibernate/TenantHibernateEventListenerSpec.groovy
@@ -73,7 +73,7 @@ class TenantHibernateEventListenerSpec extends UnitSpec {
         vetoInsert == false
     }
     
-    @Unroll("Allow #currentTenantId to allow an entity owned by #entityTenantId, #message")
+    @Unroll({"Allow #currentTenantId to allow an entity owned by #entityTenantId, #message"})
     def "allowEntityLoad tests"() {
         expect:
         def entity = new DummyEntity(tenantId: entityTenantId)
@@ -87,7 +87,7 @@ class TenantHibernateEventListenerSpec extends UnitSpec {
         123               | null            | false         | "We dont allow loading of entities without tenant id" // Can be discussed..
     }
     
-    @Unroll("Tenant id #tenantId, current tenant #currentTenantId, belongs to current tenant #belongsToCurrent")
+    @Unroll({"Tenant id #tenantId, current tenant #currentTenantId, belongs to current tenant #belongsToCurrent"})
     def "belongsToCurrentTenant tests"() {
         expect:
         def entity = new DummyEntity(tenantId: entityTenantId)

--- a/test/unit/grails/plugin/multitenant/singledb/hibernate/TenantHibernateEventProxySpec.groovy
+++ b/test/unit/grails/plugin/multitenant/singledb/hibernate/TenantHibernateEventProxySpec.groovy
@@ -30,7 +30,7 @@ class TenantHibernateEventProxySpec extends UnitSpec {
     def "events are being re-published with new event name"() {
         given:
         EventBroker mockedEventBroker = Mock()
-        HawkEventProxy proxy = new HawkEventProxy(mockedEventBroker, "tenant.created")
+        def proxy = new HawkEventProxy(mockedEventBroker, "tenant.created")
         
         when:
         Event event = new BaseEvent("hibernate.postInsert.demoTenant", null)


### PR DESCRIPTION
Hello All,

This request contains a number of changes to fix the build for Grails 2.0.0.  I don't think that any of the changes should prevent it from working in Grails 1.3.5+
- Bumped version
- Completed the upgrade to Grails 2.0
- Moved plugin definitions to BuildConfig
- Untangled plugin dependencies
- Fixed unit/integration tests

If these all look good could we also get the snapshot version released?  I need the Spring Security changes that Stefan made in December.

Thanks,
Steve
