### PR TITLE
Prevent export of spock plugin

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -46,6 +46,7 @@ grails.project.dependency.resolution = {
 
 		test(':spock:0.6-SNAPSHOT'){
 			excludes 'svn'
+			export = false
 		}
     }
     


### PR DESCRIPTION
This was breaking applications using Grails 1.3.x
