### PR TITLE
Ensure filter-mapping is added to web.xml

### DIFF
--- a/src/groovy/grails/plugin/multitenant/singledb/MtSingleDbPluginSupport.groovy
+++ b/src/groovy/grails/plugin/multitenant/singledb/MtSingleDbPluginSupport.groovy
@@ -154,9 +154,8 @@ class MtSingleDbPluginSupport {
         }
 
         def filterMappings = xml.'filter-mapping'
-        // insert tenantFilter just after grailsWebRequest and before the sitemesh filter
-        def grailsWebRequestFilterMapping = filterMappings.find  { it.'filter-name'.text() == 'grailsWebRequest' }
-        grailsWebRequestFilterMapping  + {
+        // webxml plugin is responsible for filter mapping order.  Put the filter mapping anywhere.
+        filterMappings[filterMappings.size() - 1]  + {
             'filter-mapping' {
                 'filter-name'('tenantFilter')
                 'url-pattern'('/*')


### PR DESCRIPTION
filter mapping order is now managed by the webxml plugin
No need to put the mapping in a specific location.

This means that the plugin will not work without the webxml plugin.  I don't see a problem with this since the webxml plugin seems to be fairly pervasive.  If anyone has a problem with this I can add some more robust logic to determine where the filter-mapping should be placed 
