### PR TITLE
Changed tenantId to be a Long instead of Integer.

### DIFF
--- a/grails-app/domain/demo/DemoTenant.groovy
+++ b/grails-app/domain/demo/DemoTenant.groovy
@@ -15,7 +15,7 @@ class DemoTenant implements Tenant {
         domain blank: false, unique: true
     }
 
-    Integer tenantId() {
+    Long tenantId() {
         id
     }
 }

--- a/grails-app/services/grails/plugin/multitenant/core/MultiTenantService.groovy
+++ b/grails-app/services/grails/plugin/multitenant/core/MultiTenantService.groovy
@@ -20,8 +20,8 @@ class MultiTenantService {
      * The code will be executed in a new transaction with a new session
      * to avoid other tenants entities laying in the first level cache to leak in.
      */
-    def doWithTenantId(Integer tenantId, Closure callback) {
-        Integer oldTenantId = currentTenant.get()
+    def doWithTenantId(Long tenantId, Closure callback) {
+        Long oldTenantId = currentTenant.get()
         try {
             if(log.debugEnabled) log.debug "doWithTenantId oldTenantId - $oldTenantId"
             currentTenant.set(tenantId)

--- a/src/groovy/grails/plugin/multitenant/singledb/MtSingleDbPluginSupport.groovy
+++ b/src/groovy/grails/plugin/multitenant/singledb/MtSingleDbPluginSupport.groovy
@@ -68,7 +68,7 @@ class MtSingleDbPluginSupport {
         // each tenant only sees and touches its own data.
         multiTenantHibernateFilter(FilterDefinitionFactoryBean) {
             defaultFilterCondition = ":tenantId = tenant_id"
-            parameterTypes = [ tenantId: "java.lang.Integer" ]
+            parameterTypes = [ tenantId: "java.lang.Long" ]
         }
 
         // Listens for new Hibernate sessions and enables the
@@ -123,7 +123,7 @@ class MtSingleDbPluginSupport {
 
     static createWithThisTenantMethod(Class tenantClass, MultiTenantService mtService) {
         tenantClass.metaClass.withThisTenant = { Closure closure ->
-            Integer tenantId = tenantId()
+            Long tenantId = tenantId()
             if (tenantId == null) {
                 String exMessage = ("Can't execute closure in tenent namespace without a tenant id. "
                     + "Make sure that the domain instance has been saved to database "
@@ -137,7 +137,7 @@ class MtSingleDbPluginSupport {
     }
 
     static createWithTenantIdMethod(Class tenantClass, MultiTenantService mtService) {
-        tenantClass.metaClass.'static'.withTenantId = { Integer tenantId, Closure closure ->
+        tenantClass.metaClass.'static'.withTenantId = { Long tenantId, Closure closure ->
             mtService.doWithTenantId(tenantId, closure)
         }
     }

--- a/src/java/grails/plugin/multitenant/core/CurrentTenant.java
+++ b/src/java/grails/plugin/multitenant/core/CurrentTenant.java
@@ -10,9 +10,9 @@ public interface CurrentTenant {
     String TENANT_BEFORE_CHANGE_EVENT = "multitenant.set-current-tenant.before";
     String TENANT_AFTER_CHANGE_EVENT = "multitenant.set-current-tenant.after";
 
-    Integer get();
+    Long get();
 
-    void set(Integer tenantId);
+    void set(Long tenantId);
 
     boolean isSet();
 

--- a/src/java/grails/plugin/multitenant/core/MultiTenantDomainClass.java
+++ b/src/java/grails/plugin/multitenant/core/MultiTenantDomainClass.java
@@ -13,8 +13,8 @@ package grails.plugin.multitenant.core;
  */
 public interface MultiTenantDomainClass {
 
-    Integer getTenantId();
+    Long getTenantId();
 
-    void setTenantId(Integer tenantId);
+    void setTenantId(Long tenantId);
 
 }

--- a/src/java/grails/plugin/multitenant/core/Tenant.java
+++ b/src/java/grails/plugin/multitenant/core/Tenant.java
@@ -16,6 +16,6 @@ public interface Tenant {
      * GORM to mistake it for a property and fail.
      * @return tenant id, will often be a database PK
      */
-    Integer tenantId();
+    Long tenantId();
 
 }

--- a/src/java/grails/plugin/multitenant/core/TenantRepository.java
+++ b/src/java/grails/plugin/multitenant/core/TenantRepository.java
@@ -17,6 +17,6 @@ public interface TenantRepository {
      * @return The tenant instance associated with the tenant id
      * @throws TenantNotFoundException
      */
-    Tenant findByTenantId(Integer tenantId) throws TenantNotFoundException;
+    Tenant findByTenantId(Long tenantId) throws TenantNotFoundException;
 
 }

--- a/src/java/grails/plugin/multitenant/core/ast/MultiTenantAST.java
+++ b/src/java/grails/plugin/multitenant/core/ast/MultiTenantAST.java
@@ -25,7 +25,7 @@ public class MultiTenantAST implements ASTTransformation {
     // TODO: ConstantExpression.NULL would be better, but that leads to all sorts of crazy problems
     // with default GORM constraints. It looks like it will become easier to hook into this in Grails 1.4:
     // https://github.com/grails/grails-core/blob/master/grails-core/src/main/groovy/org/codehaus/groovy/grails/validation/ConstraintsEvaluatorFactoryBean.java
-    public final static Integer NO_TENANT_VALUE = Integer.MIN_VALUE;
+    public final static Long NO_TENANT_VALUE = Long.MIN_VALUE;
 
     @Override
     public void visit(ASTNode[] astNodes, SourceUnit sourceUnit) {
@@ -45,7 +45,7 @@ public class MultiTenantAST implements ASTTransformation {
     }
 
     private void addTenantProperty(ClassNode node) {
-        ClassNode integerType = new ClassNode(Integer.class);
+        ClassNode integerType = new ClassNode(Long.class);
         ConstantExpression defaultValue = new ConstantExpression(NO_TENANT_VALUE);
         Statement getterBlock = null;
         Statement setterBlock = null;

--- a/src/java/grails/plugin/multitenant/core/exception/TenantNotFoundException.java
+++ b/src/java/grails/plugin/multitenant/core/exception/TenantNotFoundException.java
@@ -7,9 +7,9 @@ package grails.plugin.multitenant.core.exception;
 @SuppressWarnings("serial")
 public class TenantNotFoundException extends TenantException {
 
-    private Integer missingTenantId;
+    private Long missingTenantId;
 
-    public TenantNotFoundException(Integer tenantId) {
+    public TenantNotFoundException(Long tenantId) {
         super("Unable to find tenant with id " + tenantId);
         this.missingTenantId = tenantId;
     }
@@ -22,7 +22,7 @@ public class TenantNotFoundException extends TenantException {
         super(message, cause);
     }
 
-    public Integer getMissingTenantId() {
+    public Long getMissingTenantId() {
         return missingTenantId;
     }
 

--- a/src/java/grails/plugin/multitenant/core/exception/TenantSecurityException.java
+++ b/src/java/grails/plugin/multitenant/core/exception/TenantSecurityException.java
@@ -3,19 +3,19 @@ package grails.plugin.multitenant.core.exception;
 @SuppressWarnings("serial")
 public class TenantSecurityException extends TenantException {
 
-    private Integer currentTenantId, loadedTenantId;
+    private Long currentTenantId, loadedTenantId;
 
-    public TenantSecurityException(String message, Integer currentTenantId, Integer loadedTenantId) {
+    public TenantSecurityException(String message, Long currentTenantId, Long loadedTenantId) {
         super(message);
         this.currentTenantId = currentTenantId;
         this.loadedTenantId = loadedTenantId;
     }
 
-    public Integer getCurrentTenantId() {
+    public Long getCurrentTenantId() {
         return currentTenantId;
     }
 
-    public Integer getLoadedTenantId() {
+    public Long getLoadedTenantId() {
         return loadedTenantId;
     }
 

--- a/src/java/grails/plugin/multitenant/core/impl/CurrentTenantThreadLocal.java
+++ b/src/java/grails/plugin/multitenant/core/impl/CurrentTenantThreadLocal.java
@@ -10,11 +10,11 @@ import grails.plugins.hawkeventing.EventBroker;
  */
 public class CurrentTenantThreadLocal implements CurrentTenant {
 
-    private static ThreadLocal<Integer> currentTenant = new ThreadLocal<Integer>();
+    private static ThreadLocal<Long> currentTenant = new ThreadLocal<Long>();
     private EventBroker eventBroker;
 
     @Override
-    public Integer get() {
+    public Long get() {
         return currentTenant.get();
     }
 
@@ -24,7 +24,7 @@ public class CurrentTenantThreadLocal implements CurrentTenant {
     }
 
     @Override
-    public void set(Integer tenantId) {
+    public void set(Long tenantId) {
         eventBroker.publish(TENANT_BEFORE_CHANGE_EVENT, tenantId);
         currentTenant.set(tenantId);
         eventBroker.publish(TENANT_AFTER_CHANGE_EVENT, tenantId);

--- a/src/java/grails/plugin/multitenant/core/log/TenantMDC.java
+++ b/src/java/grails/plugin/multitenant/core/log/TenantMDC.java
@@ -20,7 +20,7 @@ public class TenantMDC {
 
     @Consuming(CurrentTenant.TENANT_AFTER_CHANGE_EVENT)
     public void currentTenantUpdated(Event event) {
-        Integer tenantId = (Integer) event.getPayload();
+        Long tenantId = (Long) event.getPayload();
         String tenant = (tenantId == null) ? "no-tenant" : "tenant-" + tenantId;
         MDC.put("tenant", tenant);
     }

--- a/src/java/grails/plugin/multitenant/core/resolve/TenantResolver.java
+++ b/src/java/grails/plugin/multitenant/core/resolve/TenantResolver.java
@@ -23,6 +23,6 @@ public interface TenantResolver {
      * @return tenant id, don't return 'null' unless you know what you're doing
      * @throws TenantResolveException
      */
-    Integer resolve(HttpServletRequest request) throws TenantResolveException;
+    Long resolve(HttpServletRequest request) throws TenantResolveException;
 
 }

--- a/src/java/grails/plugin/multitenant/core/servlet/CurrentTenantServletFilter.java
+++ b/src/java/grails/plugin/multitenant/core/servlet/CurrentTenantServletFilter.java
@@ -46,7 +46,7 @@ public class CurrentTenantServletFilter implements Filter {
         try {
             if (request instanceof HttpServletRequest) {
                 HttpServletRequest httpRequest = (HttpServletRequest) request;
-                Integer currentTenantId = tenantResolver.resolve(httpRequest);
+                Long currentTenantId = tenantResolver.resolve(httpRequest);
                 currentTenant.set(currentTenantId);
             }
 

--- a/src/java/grails/plugin/multitenant/core/spring/TenantScope.java
+++ b/src/java/grails/plugin/multitenant/core/spring/TenantScope.java
@@ -30,7 +30,7 @@ public class TenantScope implements Scope, ApplicationContextAware {
     private CurrentTenant currentTenant;
     private ApplicationContext applicationContext;
 
-    private ConcurrentHashMap<Integer, Map<String, Object>> tenantBeanCache = new ConcurrentHashMap<Integer, Map<String, Object>>(50);
+    private ConcurrentHashMap<Long, Map<String, Object>> tenantBeanCache = new ConcurrentHashMap<Long, Map<String, Object>>(50);
 
     /**
      * Return the object with the given name from the underlying scope, creating
@@ -38,9 +38,9 @@ public class TenantScope implements Scope, ApplicationContextAware {
      */
     @Override
     public Object get(String name, ObjectFactory<?> objectFactory) {
-        Integer tenantId = currentTenant.get();
+        Long tenantId = currentTenant.get();
         if (tenantId == null) { // ConcurrentHashMap does not allow nulls, so mapping to -1
-            tenantId = -1;
+            tenantId = -1L;
         }
         Map<String, Object> beanCache = getBeanCacheForTenant(tenantId);
         if (!beanCache.containsKey(name)) {
@@ -50,7 +50,7 @@ public class TenantScope implements Scope, ApplicationContextAware {
         return beanCache.get(name);
     }
 
-    private Map<String, Object> getBeanCacheForTenant(Integer tenantId) {
+    private Map<String, Object> getBeanCacheForTenant(Long tenantId) {
         if (!tenantBeanCache.containsKey(tenantId)) {
             tenantBeanCache.put(tenantId, new ConcurrentHashMap<String, Object>(10));
         }

--- a/src/java/grails/plugin/multitenant/singledb/hibernate/TenantHibernateEventListener.java
+++ b/src/java/grails/plugin/multitenant/singledb/hibernate/TenantHibernateEventListener.java
@@ -52,7 +52,7 @@ public class TenantHibernateEventListener implements PreInsertEventListener, Pre
                         + event.getEntity().getClass().getSimpleName() + "', but no tenant is set");
             }
 
-            Integer currentTenantId = currentTenant.get();
+            Long currentTenantId = currentTenant.get();
             hibernateEventPropertyUpdater.updateProperty(event, MultiTenantAST.TENANT_ID_FIELD_NAME, currentTenantId);
             MultiTenantDomainClass entity = (MultiTenantDomainClass) event.getEntity();
             entity.setTenantId(currentTenantId);
@@ -68,9 +68,9 @@ public class TenantHibernateEventListener implements PreInsertEventListener, Pre
     @Override
     public boolean onPreUpdate(PreUpdateEvent event) {
         if (isMultiTenantEntity(event.getEntity())) {
-            Integer currentTenantId = currentTenant.get();
+            Long currentTenantId = currentTenant.get();
             MultiTenantDomainClass entity = (MultiTenantDomainClass) event.getEntity();
-            Integer entityTenantId = entity.getTenantId();
+            Long entityTenantId = entity.getTenantId();
             if (currentTenantId != null && !currentTenantId.equals(entityTenantId)) {
                 throw new TenantSecurityException("Tried to update '" + event.getEntity() + "' with another tenant id. Expected "
                         + currentTenantId + ", found " + entityTenantId, currentTenantId, entityTenantId);
@@ -85,7 +85,7 @@ public class TenantHibernateEventListener implements PreInsertEventListener, Pre
         Object LoadedEntity = event.getResult();
         if (LoadedEntity != null && isMultiTenantEntity(LoadedEntity)) {
             MultiTenantDomainClass entity = (MultiTenantDomainClass) LoadedEntity;
-            Integer currentTenantId = currentTenant.get();
+            Long currentTenantId = currentTenant.get();
 
             // We won't be able to extract tenant-id from an association fetch.
             // TODO: This is a bit scary as it means that we potentially can load entities from
@@ -97,7 +97,7 @@ public class TenantHibernateEventListener implements PreInsertEventListener, Pre
         }
     }
 
-    protected boolean allowEntityLoad(Integer currentTenantId, MultiTenantDomainClass entity) {
+    protected boolean allowEntityLoad(Long currentTenantId, MultiTenantDomainClass entity) {
         if (currentTenantId != null) {
             if (belongsToCurrentTenant(currentTenantId, entity)) {
                 return true;
@@ -127,7 +127,7 @@ public class TenantHibernateEventListener implements PreInsertEventListener, Pre
         //                MultiTenantDomainClass tenantEntity = (MultiTenantDomainClass) entity;
         //                System.out.println(" -> post load tenant id: " + tenantEntity.getTenantId());
         //
-        //                Integer tenantEntityId = tenantEntity.getTenantId();
+        //                Long tenantEntityId = tenantEntity.getTenantId();
         //                if (!currentTenant.get().equals(tenantEntityId)) {
         //                    System.out.println(" -> Warning! Detected another tenant");
         //                    throw new TenantSecurityException("Tried to load '" + tenantEntity + "' with another tenant id. Expected "
@@ -143,7 +143,7 @@ public class TenantHibernateEventListener implements PreInsertEventListener, Pre
         boolean shouldVetoDelete = false;
         if (isMultiTenantEntity(event.getEntity())) {
             MultiTenantDomainClass tenantEntity = (MultiTenantDomainClass) event.getEntity();
-            Integer currentTenantId = currentTenant.get();
+            Long currentTenantId = currentTenant.get();
 
             if (currentTenantId != null && !belongsToCurrentTenant(currentTenantId, tenantEntity)) {
                 log.warn("Tenant {} tried to delete another tenants entity {}", currentTenant.get(), tenantEntity);
@@ -154,8 +154,8 @@ public class TenantHibernateEventListener implements PreInsertEventListener, Pre
         return shouldVetoDelete;
     }
 
-    protected boolean belongsToCurrentTenant(Integer currentTenantId, MultiTenantDomainClass entity) {
-        Integer entityTenantId = entity.getTenantId();
+    protected boolean belongsToCurrentTenant(Long currentTenantId, MultiTenantDomainClass entity) {
+        Long entityTenantId = entity.getTenantId();
         return currentTenantId != null && currentTenantId.equals(entityTenantId);
     }
 

--- a/src/java/grails/plugin/multitenant/singledb/hibernate/TenantHibernateFilterEnabler.java
+++ b/src/java/grails/plugin/multitenant/singledb/hibernate/TenantHibernateFilterEnabler.java
@@ -29,14 +29,14 @@ public class TenantHibernateFilterEnabler {
     @Consuming("hibernate.sessionCreated")
     public void newHibernateSessionCreated(Event event) {
         Session newSession = (Session) event.getPayload();
-        Integer currentTenantId = currentTenant.get();
+        Long currentTenantId = currentTenant.get();
         updateFilterParameter(newSession, currentTenantId);
     }
 
     @Consuming(CurrentTenant.TENANT_AFTER_CHANGE_EVENT)
     public void currentTenantUpdated(Event event) {
         if (hasSessionBoundToThread()) {
-            Integer updatedTenantId = (Integer) event.getPayload();
+            Long updatedTenantId = (Long) event.getPayload();
             Session currentSession = sessionFactory.getCurrentSession();
             updateFilterParameter(currentSession, updatedTenantId);
         }
@@ -46,7 +46,7 @@ public class TenantHibernateFilterEnabler {
         return TransactionSynchronizationManager.hasResource(sessionFactory);
     }
 
-    private void updateFilterParameter(Session session, Integer tenantId) {
+    private void updateFilterParameter(Session session, Long tenantId) {
         if (tenantId != null) {
             enableHibernateFilterForTenant(session, tenantId);
         } else {
@@ -55,7 +55,7 @@ public class TenantHibernateFilterEnabler {
     }
 
     @SuppressWarnings("unchecked")
-    private void enableHibernateFilterForTenant(Session session, Integer tenantId) {
+    private void enableHibernateFilterForTenant(Session session, Long tenantId) {
         String filterName = multiTenantHibernateFilter.getFilterName();
         Set<String> paramNames = multiTenantHibernateFilter.getParameterNames();
         String paramName = paramNames.iterator().next();

--- a/src/templates/DefaultTenantRepository.groovy.template
+++ b/src/templates/DefaultTenantRepository.groovy.template
@@ -21,7 +21,7 @@ public class ${tenantRepositoryClassName} implements CurrentTenantAwareRepositor
     @Override
     Tenant getCurrentTenant() {
         Tenant tenantInstance = null
-        Integer currentTenantId = currentTenant.get()
+        Long currentTenantId = currentTenant.get()
         if (currentTenantId != null) {
             tenantInstance = findByTenantId(currentTenantId)
         }
@@ -30,7 +30,7 @@ public class ${tenantRepositoryClassName} implements CurrentTenantAwareRepositor
     }
 
     @Override
-    Tenant findByTenantId(Integer tenantId) {
+    Tenant findByTenantId(Long tenantId) {
         ${tenantDomainClassName}.get(tenantId); // Assuming that you use ${tenantDomainClassName}'s primary key as tenant id
     }
 }

--- a/src/templates/SpringSecurityTenantRepository.groovy.template
+++ b/src/templates/SpringSecurityTenantRepository.groovy.template
@@ -24,7 +24,7 @@ public class ${tenantRepositoryClassName} implements CurrentTenantAwareRepositor
     @Override
     Tenant getCurrentTenant() {
         Tenant tenantInstance = null
-        Integer currentTenantId = currentTenant.get()
+        Long currentTenantId = currentTenant.get()
         if (currentTenantId != null) {
             tenantInstance = findByTenantId(currentTenantId)
         }
@@ -33,7 +33,7 @@ public class ${tenantRepositoryClassName} implements CurrentTenantAwareRepositor
     }
 
     @Override
-    Tenant findByTenantId(Integer tenantId) {
+    Tenant findByTenantId(Long tenantId) {
         def tenantClass = grailsApplication.getDomainClass(grailsApplication.config.multiTenant.tenantClass)
         tenantClass.clazz.get(tenantId); // Assumes that you use Tenant's primary key as tenant id
     }

--- a/src/templates/SpringSecurityTenantResolverSkeleton.groovy.template
+++ b/src/templates/SpringSecurityTenantResolverSkeleton.groovy.template
@@ -13,7 +13,7 @@ import javax.servlet.http.HttpServletRequest
 class ${tenantResolverClassName} implements TenantResolver {
     def springSecurityService
 
-    Integer resolve(HttpServletRequest request) throws TenantResolveException {
+    Long resolve(HttpServletRequest request) throws TenantResolveException {
         def user = springSecurityService.getCurrentUser()
         /*
         if (!user) {

--- a/src/templates/TenantDomainClass.groovy.template
+++ b/src/templates/TenantDomainClass.groovy.template
@@ -15,7 +15,7 @@ class ${tenantDomainClassName} implements Tenant {
         name blank: false, unique: true
     }
 
-    Integer tenantId() {
+    Long tenantId() {
         id
     }
 }

--- a/src/templates/TenantResolverSkeleton.groovy.template
+++ b/src/templates/TenantResolverSkeleton.groovy.template
@@ -11,7 +11,7 @@ import javax.servlet.http.HttpServletRequest
  */
 class ${tenantResolverClassName} implements TenantResolver {
 
-    Integer resolve(HttpServletRequest request) throws TenantResolveException {
+    Long resolve(HttpServletRequest request) throws TenantResolveException {
         String host = request.getServerName()
         switch (host) {
             case "john.greatapp.com":

--- a/test/integration/grails/plugin/multitenant/singledb/hibernate/TenantHibernateEventListenerIntegrationSpec.groovy
+++ b/test/integration/grails/plugin/multitenant/singledb/hibernate/TenantHibernateEventListenerIntegrationSpec.groovy
@@ -164,7 +164,7 @@ class TenantHibernateEventListenerIntegrationSpec extends IntegrationSpec {
 //        assert session.createSQLQuery("insert into demo_pet_owner(version, name, tenant_id) values(0, 'Mickey Mouse', 567)").executeUpdate() == 1
 //
 //        when:
-//        Integer mickeyId = Tenant.withTenantId(567) {
+//        Long mickeyId = Tenant.withTenantId(567) {
 //            DemoPetOwner.findByName("Mickey Mouse")?.id
 //        }
 //

--- a/test/integration/grails/plugin/multitenant/singledb/hibernate/TenantHibernateFilterEnablerSpec.groovy
+++ b/test/integration/grails/plugin/multitenant/singledb/hibernate/TenantHibernateFilterEnablerSpec.groovy
@@ -47,6 +47,6 @@ class TenantHibernateFilterEnablerSpec extends IntegrationSpec {
         enabledFilter.getParameter("tenantId") == tenantId
 
         where:
-        tenantId << [ -1, 0, 1 ]
+        tenantId << [ -1L, 0L, 1L ]
     }
 }

--- a/test/unit/grails/plugin/multitenant/core/ast/MultiTenantASTSpec.groovy
+++ b/test/unit/grails/plugin/multitenant/core/ast/MultiTenantASTSpec.groovy
@@ -15,7 +15,7 @@ class MultiTenantASTSpec extends UnitSpec {
         expect:
         SampleDomainClass.declaredFields.find { Field field ->
             field.name == "tenantId"
-            field.type == Integer
+            field.type == Long
         }
     }
 

--- a/test/unit/grails/plugin/multitenant/singledb/MtSingleDbPluginSupportSpec.groovy
+++ b/test/unit/grails/plugin/multitenant/singledb/MtSingleDbPluginSupportSpec.groovy
@@ -71,8 +71,8 @@ class MtSingleDbPluginSupportSpec extends UnitSpec {
     }
 
     private class MetaTenant implements Tenant {
-        Integer id
-        Integer tenantId = 123
-        Integer tenantId() { tenantId }
+        Long id
+        Long tenantId = 123
+        Long tenantId() { tenantId }
     }
 }

--- a/test/unit/grails/plugin/multitenant/singledb/hibernate/TenantHibernateEventListenerSpec.groovy
+++ b/test/unit/grails/plugin/multitenant/singledb/hibernate/TenantHibernateEventListenerSpec.groovy
@@ -135,5 +135,5 @@ class TenantHibernateEventListenerSpec extends UnitSpec {
 }
 
 class DummyEntity implements MultiTenantDomainClass {
-    Integer tenantId
+    Long tenantId
 }

--- a/test/unit/grails/plugin/multitenant/singledb/hibernate/TenantHibernateFilterEnablerUnitSpec.groovy
+++ b/test/unit/grails/plugin/multitenant/singledb/hibernate/TenantHibernateFilterEnablerUnitSpec.groovy
@@ -16,7 +16,7 @@ class TenantHibernateFilterEnablerUnitSpec extends UnitSpec {
 
     TenantHibernateFilterEnabler filterEnabler
     FilterDefinition filterDefinition = new FilterDefinition (
-        "multiTenantHibernateFilter", ":tenantId = tennatId", [ "tenantId": "java.lang.Integer" ])
+        "multiTenantHibernateFilter", ":tenantId = tennatId", [ "tenantId": "java.lang.Long" ])
 
     def setup() {
         filterEnabler = new TenantHibernateFilterEnabler()


### PR DESCRIPTION
No idea if this is a useful contribution, but easy enough to do so I thought I'd suggest it:

Updated so that `tenantId` is a `Long` rather than an `Integer`.  This is in line with the GORM standard, and makes things work better

```
def m = MyDomainClass.build()
TenantClass.withTenantId(m.id.toInteger()) { ... } // toInteger, or 'as Integer', currently required
```
